### PR TITLE
INFRA-405: Allow providing Maven arguments at all steps

### DIFF
--- a/.github/workflows/build-publish-workflow.yml
+++ b/.github/workflows/build-publish-workflow.yml
@@ -35,6 +35,7 @@ jobs:
         run: "mvn --batch-mode clean package ${{ inputs.maven-args }}"
 
   publish:
+    needs: build
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' }}
     steps:

--- a/.github/workflows/build-publish-workflow.yml
+++ b/.github/workflows/build-publish-workflow.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up JDK 8
         uses: actions/setup-java@v2
@@ -32,14 +32,13 @@ jobs:
           distribution: 'temurin'
           java-version: '8'
       - name: Build
-        run: mvn --batch-mode clean package
-
+        run: "mvn --batch-mode clean package ${{ inputs.maven-args }}"
 
   publish:
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up JDK 8
         uses: actions/setup-java@v2
@@ -61,8 +60,10 @@ jobs:
               "username": "${{ secrets.NEXUS_USERNAME }}",
               "password": "${{ secrets.NEXUS_PASSWORD }}"
             }]
-      - name: Build and Publish
+
+      - name: Publish
         run: "mvn --batch-mode clean deploy ${{ inputs.maven-args }}"
+
       - name: Notify OCD3
         uses: distributhor/workflow-webhook@v3
         env:

--- a/.github/workflows/build-publish-workflow.yml
+++ b/.github/workflows/build-publish-workflow.yml
@@ -52,7 +52,12 @@ jobs:
         with:
           servers: |
             [{
-              "id": "mks-nexus-private",
+              "id": "mks-nexus-public-snapshots",
+              "username": "${{ secrets.NEXUS_USERNAME }}",
+              "password": "${{ secrets.NEXUS_PASSWORD }}"
+            },
+            {
+              "id": "mks-nexus-public-releases",
               "username": "${{ secrets.NEXUS_USERNAME }}",
               "password": "${{ secrets.NEXUS_PASSWORD }}"
             },
@@ -60,7 +65,13 @@ jobs:
               "id": "mks-nexus-private-snapshots",
               "username": "${{ secrets.NEXUS_USERNAME }}",
               "password": "${{ secrets.NEXUS_PASSWORD }}"
-            }]
+            },
+            {
+              "id": "mks-nexus-private-releases",
+              "username": "${{ secrets.NEXUS_USERNAME }}",
+              "password": "${{ secrets.NEXUS_PASSWORD }}"
+            }
+            ]
 
       - name: Publish
         run: "mvn --batch-mode clean deploy ${{ inputs.maven-args }}"


### PR DESCRIPTION
https://mekomsolutions.atlassian.net/browse/INFRA-405

- Ability to provide Maven args to the build command.
- Made jobs depend on one another
- Some clean up in naming
- Update checkout action to v3 (deprecation notice from GitHub)
- Allow publishing on public repos too.