### PR TITLE
Add `free-disk-space` option to Maven workflows

### DIFF
--- a/.github/workflows/maven-build-test.yml
+++ b/.github/workflows/maven-build-test.yml
@@ -33,6 +33,11 @@ on:
         required: false
         type: boolean
         default: false
+      free-disk-space:
+        description: 'Whether to free disk space before running the build'
+        required: false
+        type: boolean
+        default: false
 
     secrets:
       NEXUS_USERNAME:
@@ -49,6 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Free Disk Space (Ubuntu)
+        if: ${{ inputs.free-disk-space }}
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: false

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -33,6 +33,11 @@ on:
         required: false
         type: string
         default: 'artifact'
+      free-disk-space:
+        description: 'Whether to free disk space before running the build'
+        required: false
+        type: boolean
+        default: false
     secrets:
       NEXUS_USERNAME:
         required: true
@@ -50,6 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Free Disk Space (Ubuntu)
+        if: ${{ inputs.free-disk-space }}
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: false

--- a/docs/maven-build-test.md
+++ b/docs/maven-build-test.md
@@ -11,6 +11,7 @@ The workflow is triggered when it is called from another workflow.
 - `maven-args`: Additional arguments to pass to Maven. Default is `-DskipTests=false`.
 - `java-version`: Java version to use for building. Default is `17`.
 - `java-distribution`: Java distribution to use for building. Default is `temurin`.
+- `free-disk-space`: If set to `true`, it will check for free disk space before running the build. Default is `false`.
 
 ## Jobs
 
@@ -34,6 +35,7 @@ jobs:
       maven-args: -DskipTests=false # Optional default value: -DskipTests=false
       java-version: 17 # Optional default value: 17
       java-distribution: temurin # Optional default value: temurin
+      free-disk-space: false # Optional default value: false
     secrets:
       NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
       NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}


### PR DESCRIPTION
This PR adds the ability to enable/disable "Free Disk Space" step, defaults to `false`. This step takes up to ~ 3 mins to finish thus making the GA builds slow. Making it configurable allows us to choose when to enable or disable.